### PR TITLE
Fix storage restart error

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -69,4 +69,7 @@ done
 # 	echo
 #     echo
 # fi
-tail -f "$FASTDFS_LOG_FILE"
+
+if [ -f "$FASTDFS_LOG_FILE" ]; then 
+	tail -f "$FASTDFS_LOG_FILE"
+fi


### PR DESCRIPTION
The log file with not exist when restart the container, and the endpoint with trigger an error. so the container will not start.